### PR TITLE
$idempotenceKey usage

### DIFF
--- a/docs/examples/02-payments.md
+++ b/docs/examples/02-payments.md
@@ -174,7 +174,7 @@ try {
     $request->setDescription($request->getDescription() . ' - merchant comment');
 
     $idempotenceKey = uniqid('', true);
-    $response = $client->createPayment($request);
+    $response = $client->createPayment($request, $idempotenceKey);
     
     //получаем confirmationUrl для дальнейшего редиректа
     $confirmationUrl = $response->getConfirmation()->getConfirmationUrl();


### PR DESCRIPTION
В примере создания платежа через builder определялся $idempotenceKey, но не передавался в createPayment()